### PR TITLE
add snp_mapping for finngen, max input decimals, decode format

### DIFF
--- a/data/formatbook.json
+++ b/data/formatbook.json
@@ -48,6 +48,25 @@
             "EQUALS": "EQUALS"
         }
     },
+    "snp_mapping_rsid": {
+        "meta_data": {
+            "format_name": "snp_mapping_rsid",
+            "format_source": "",
+            "format_version": "20240423",
+            "format_col_order": [
+                "PREVIOUS_rsID",
+                "SNPID",
+                "PREVIOUS_ID",
+                "EQUALS"
+            ]
+        },
+        "format_dict": {
+            "PREVIOUS_rsID": "PREVIOUS_rsID",
+            "SNPID": "SNPID",
+            "PREVIOUS_ID": "PREVIOUS_ID",
+            "EQUALS": "EQUALS"
+        }
+    },
     "metal": {
         "meta_data": {
             "format_name": "metal",


### PR DESCRIPTION
Added: 
(1) method to generate snp_mapping tables for finngen input (i.e. when only rsID is available, SNPID is manually created) (#10);
(2) method to format the output based on the maximum decimal number of the float input columns (default), unless the float parameter (`gl_params["float_formats"]`) is specified in the configuration file (#11);
(3) decode format for input summary statistics (#12)
